### PR TITLE
Add paddings to Stack and create Layout function

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -1,0 +1,40 @@
+package ui
+
+// Recursively removes border margins and padding from controls, replaces
+// nil values with stretchy spaces and reorients nested stack to have
+// opposing orientations.
+func resetControls(parent *Stack) {
+	for i, control := range parent.controls {
+		switch control.(type) {
+		case *Stack:
+			stack := control.(*Stack)
+			stack.borderMargin = 0
+			stack.orientation = !parent.orientation
+			resetControls(stack)
+		case nil:
+			emptySpace := newStack(horizontal)
+			parent.controls[i] = emptySpace
+			parent.stretchy[i] = true
+		}
+	}
+}
+
+// Creates a new Stack from the given controls. The topmost Stack will have
+// vertical orientation and margin borders, with each nested stack being
+// oriented oppositely. Controls are displayed with a default padding
+// between them.
+func Layout(controls ...Control) *Stack {
+	stack := &Stack{
+		orientation:  vertical,
+		controls:     controls,
+		stretchy:     make([]bool, len(controls)),
+		width:        make([]int, len(controls)),
+		height:       make([]int, len(controls)),
+		padding:      10,
+		borderMargin: 15,
+	}
+
+	resetControls(stack)
+
+	return stack
+}


### PR DESCRIPTION
I tried to make an intuitive function to quickly create good-looking layouts. I liked the result, but I understand if you don't want to increase the API size right now, so this is only a suggestion. Anyway, the padding/margin code may be useful by itself.

This change is twofold:
- First, add unexported attributes `padding` and `marginBorder` to `Stack` that work as expected. I'm open to name suggestions here.
- Second, export a function `Layout` that creates a stack with automatic orientation, padding and border.

`Layout` works by giving only the topmost stacks a margin, and settings its orientation to "vertical". All nested stacks inside it are oriented perpendicular to its parent and have only padding, not margin. As a bonus, any `nil` value is converted to a stretchy space.

So for example, this code:

``` go
w := ui.NewWindow("Test Window", 400, 250)
w.Open(ui.Layout(ui.NewLabel("Task Description"),
    ui.NewProgressBar(),
    nil,
    ui.Layout(ui.NewButton("Button 1"),
        ui.NewLineEdit("Edit"),
        nil,
        ui.Layout(ui.NewButton("Button 2"),
            ui.NewButton("Button 3"),
            ui.NewButton("Button 4")),
        ui.Layout(ui.NewButton("Button 5"),
            nil,
            ui.NewButton("Button 6")))))
```

Creates this layout:

![goui](https://cloud.githubusercontent.com/assets/231856/3353863/04dd1c24-fa8f-11e3-9bf6-6447619f4340.png)

I personally liked the results and will be using the function, merging or not. I'm also considering making a `Stretch` function, so you can write `ui.Layout(button1, ui.Stretch(button2), button3)` but right now I can't think of an elegant implementation because the stretching information is on the parent.
