### PR TITLE
area_windows.go: proposing use of github.com/akavel/winq

### DIFF
--- a/controls_windows.go
+++ b/controls_windows.go
@@ -26,7 +26,6 @@ func CheckRadioButton(hDlg HWND, nIDFirstButton int, nIDLastButton int, nIDCheck
 */
 
 var (
-	_getScrollInfo  = user32.NewProc("GetScrollInfo")
 	_setScrollInfo  = user32.NewProc("SetScrollInfo")
 	_scrollWindowEx = user32.NewProc("ScrollWindowEx")
 )

--- a/stdwndclass_windows.go
+++ b/stdwndclass_windows.go
@@ -71,7 +71,7 @@ func storeSysData(hwnd _HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) _LRES
 var (
 	_getFocus = user32.NewProc("GetFocus")
 	_isChild  = user32.NewProc("IsChild")
-	// _setFocus in area_windows.go
+	_setFocus = user32.NewProc("SetFocus")
 )
 
 // this is needed to ensure focus is preserved when switching away from and back to our program

--- a/sysdata_windows.go
+++ b/sysdata_windows.go
@@ -610,6 +610,10 @@ func (s *sysData) repaintAll() {
 	<-ret
 }
 
+var (
+	_getSystemMetrics = user32.NewProc("GetSystemMetrics")
+)
+
 func (s *sysData) center() {
 	ret := make(chan struct{})
 	defer close(ret)


### PR DESCRIPTION
Hi,

I've created a small package [named "winq"](http://godoc.org/github.com/akavel/winq) for easier access to WinAPI and faster prototyping in it. Maybe you would be interested?

To give you an example, I modified the `area_windows.go` file in your repo, aiming to showcase how it could look like with winq. To highlight some angles:

  * You might want to have a look e.g. at the `EndPaint` call, how it can be used with `defer` now.
  * Also, one of my core goals in the package was to simplify error handling -- for example, the most common [`Try.N()`](http://godoc.org/github.com/akavel/winq#Try.N) function verifies that the result of a WinAPI call is Nonzero (thus "N"), otherwise it sets the `Try.Err` field with detected error message.

Hope this could make your life somewhat easier!
Cheers,
/Mateusz Czapliński.