### PR TITLE
Fix warnings on Windows

### DIFF
--- a/comctl32_windows.c
+++ b/comctl32_windows.c
@@ -120,7 +120,7 @@ DWORD initCommonControls(char **errmsg)
 	LOAD("DefSubclassProc");
 	fv_DefSubclassProc = (LRESULT (*WINAPI)(HWND, UINT, WPARAM, LPARAM)) f;
 	LOAD("_TrackMouseEvent");
-	fv__TrackMouseEvent = (HIMAGELIST (*WINAPI)(int, int, UINT, int, int)) f;
+	fv__TrackMouseEvent = (BOOL (*WINAPI)(LPTRACKMOUSEEVENT)) f;
 
 	if ((*ficc)(&icc) == FALSE) {
 		*errmsg = "error initializing Common Controls (comctl32.dll)";

--- a/table_windows.c
+++ b/table_windows.c
@@ -10,7 +10,7 @@ LPWSTR xtableWindowClass = tableWindowClass;
 
 void doInitTable(void)
 {
-	initTable(xpanic, fv__TrackMouseEvent);
+	initTable((void (*)(const char *, DWORD)) xpanic, fv__TrackMouseEvent);
 }
 
 static LRESULT CALLBACK tableSubProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR id, DWORD_PTR data)


### PR DESCRIPTION
Following warnings occurred on Windows:

```
$ go get github.com/andlabs/ui
# github.com/andlabs/ui
C:\WORK\Go\src\github.com\andlabs\ui\comctl32_windows.c: In function 'initCommonControls':
C:\WORK\Go\src\github.com\andlabs\ui\comctl32_windows.c:123:22: warning: assignment from incompatible pointer type
  fv__TrackMouseEvent = (HIMAGELIST (*WINAPI)(int, int, UINT, int, int)) f;
                      ^
# github.com/andlabs/ui
C:\WORK\Go\src\github.com\andlabs\ui\table_windows.c: In function 'doInitTable':
C:\WORK\Go\src\github.com\andlabs\ui\table_windows.c:13:12: warning: passing argument 1 of 'initTable' from incompatible pointer type
  initTable(xpanic, fv__TrackMouseEvent);
            ^
In file included from C:\WORK\Go\src\github.com\andlabs\ui\table_windows.c:6:0:
C:\WORK\Go\src\github.com\andlabs\ui\wintable/main.h:144:6: note: expected 'void (*)(const char *, DWORD)' but argument is of type 'void (*)(char *, DWORD)'
 void initTable(void (*panicfunc)(const char *msg, DWORD lastError), BOOL (*WINAPI tme)(LPTRACKMOUSEEVENT))
      ^
```

This PR fixes them.