### PR TITLE
Fixed float display for table values on unix.

### DIFF
--- a/table_unix.go
+++ b/table_unix.go
@@ -182,6 +182,18 @@ func goTableModel_do_get_value(data unsafe.Pointer, row C.gint, col C.gint, valu
 		d := datum.Interface().(bool)
 		C.g_value_init(value, C.G_TYPE_BOOLEAN)
 		C.g_value_set_boolean(value, togbool(d))
+	case datum.Kind() == reflect.Float64:
+	    s := fmt.Sprintf("%.8f", datum.Interface().(float64))
+		str := togstr(s)
+		defer freegstr(str)
+		C.g_value_init(value, C.G_TYPE_STRING)
+		C.g_value_set_string(value, str)
+	case datum.Kind() == reflect.Float32:
+	    s := fmt.Sprintf("%f", datum.Interface().(float32))
+		str := togstr(s)
+		defer freegstr(str)
+		C.g_value_init(value, C.G_TYPE_STRING)
+		C.g_value_set_string(value, str)
 	default:
 		s := fmt.Sprintf("%v", datum)
 		str := togstr(s)


### PR DESCRIPTION
Float64 is using fmt.Sprintf("%.8f", datum.Interface().(float64))
and
Float32 is using fmt.Sprintf("%f", datum.Interface().(float32))

These are the formats I needed for my current project, but you
can imagine that ui library users will want to be able to specify
the format strings themselves. Could this be implemented with
struct keys?

I don't have access to other platforms, so I didn't implement it
for darwin or windows.