### PR TITLE
Reduce some warnings on OS X

### DIFF
--- a/basicctrls_darwin.m
+++ b/basicctrls_darwin.m
@@ -275,7 +275,7 @@ id newTextbox(void)
 	return (id) tv;
 }
 
-char *textboxText(id tv)
+const char *textboxText(id tv)
 {
 	return [[toNSTextView(tv) string] UTF8String];
 }

--- a/dialog_darwin.m
+++ b/dialog_darwin.m
@@ -5,6 +5,8 @@
 
 #define toNSWindow(x) ((NSWindow *) (x))
 
+void finishOpenFile(char* fname, void* data);
+
 void openFile(id parent, void *data)
 {
 	NSOpenPanel *op;

--- a/objc_darwin.h
+++ b/objc_darwin.h
@@ -82,7 +82,7 @@ extern id newGroup(id);
 extern const char *groupText(id);
 extern void groupSetText(id, char *);
 extern id newTextbox(void);
-extern char *textboxText(id);
+extern const char *textboxText(id);
 extern void textboxSetText(id, char *);
 extern id newProgressBar(void);
 extern intmax_t progressbarPercent(id);

--- a/spinbox_darwin.m
+++ b/spinbox_darwin.m
@@ -21,7 +21,7 @@
 
 @implementation goSpinbox
 
-- (id)initWithMinimum:(NSInteger)minimum maximum:(NSInteger)maximum
+- (id)initWithMinimum:(NSInteger)min maximum:(NSInteger)max
 {
 	self = [super init];
 	if (self == nil)
@@ -45,20 +45,20 @@
 
 	// TODO how SHOULD the formatter treat invald input?
 
-	[self setMinimum:minimum];
-	[self setMaximum:maximum];
-	[self setValue:self->minimum];
+	[self setMinimum:min];
+	[self setMaximum:max];
+	[self setIntegerValue:self->minimum];
 
-	[self->textfield setDelegate:self];
+	[self->textfield setDelegate:(id<NSTextFieldDelegate>)(self)];
 	[self->stepper setTarget:self];
 	[self->stepper setAction:@selector(stepperClicked:)];
 
 	return self;
 }
 
-- (void)setValue:(NSInteger)value
+- (void)setIntegerValue:(NSInteger)val
 {
-	self->value = value;
+	self->value = val;
 	if (self->value < self->minimum)
 		self->value = self->minimum;
 	if (self->value > self->maximum)
@@ -83,13 +83,13 @@
 
 - (IBAction)stepperClicked:(id)sender
 {
-	[self setValue:[self->stepper integerValue]];
+	[self setIntegerValue:[self->stepper integerValue]];
 	spinboxChanged(self->gospinbox);
 }
 
 - (void)controlTextDidChange:(NSNotification *)note
 {
-	[self setValue:[self->textfield integerValue]];
+	[self setIntegerValue:[self->textfield integerValue]];
 	spinboxChanged(self->gospinbox);
 }
 
@@ -121,5 +121,5 @@ intmax_t spinboxValue(id spinbox)
 
 void spinboxSetValue(id spinbox, intmax_t value)
 {
-	[togoSpinbox(spinbox) setValue:((NSInteger) value)];
+	[togoSpinbox(spinbox) setIntegerValue:((NSInteger) value)];
 }

--- a/uitask_darwin.m
+++ b/uitask_darwin.m
@@ -37,6 +37,8 @@ static Class areaClass;
 			case NSFlagsChanged:
 				handled = [focused doFlagsChanged:e];
 				break;
+			default:
+				break;
 			}
 	}
 	if (!handled)


### PR DESCRIPTION
This PR reduces some warnings when compiling ui on OS X.

- Add `const`.
- Add casts
- Add `default` clause to a switch
- Rename some variables not to be duplicated with instance variables.
- Rename `setValue` to `setIntegerValue` because it seemed like `setValue` was recognized as an existing function by the compiler even though there is no such definition (even in NSObject).

There are still some warnings at ui_darwin.m. Those warnings are for calling methods for an `id` value. It seemed difficult to fix as long as the class `goAreaView` is obtained dynamically.