### PR TITLE
fixing default window closing

### DIFF
--- a/window.go
+++ b/window.go
@@ -127,10 +127,11 @@ func (w *Window) OnClosing(f func(*Window) bool) {
 func doOnClosing(ww *C.uiWindow, data unsafe.Pointer) C.int {
 	w := windows[ww]
 	if w.onClosing == nil {
-		return 0
+		return 1
 	}
 	if w.onClosing(w) {
 		w.Destroy()
+		return 1
 	}
 	return 0
 }


### PR DESCRIPTION
when returns 0, window will not close.

* run `go test`
* go to "Page 2"
* Click on "Open Menued Window" or "Open Menuless Window" and try close it

- - - - -
go version go1.6.2 darwin/amd64
os x el capitan 10.11.4