### PR TITLE
Fix the support of "updateui.go" in Windows

### DIFF
--- a/examples/updateui.go
+++ b/examples/updateui.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/andlabs/ui"
+	_ "github.com/andlabs/ui/winmanifest"
 )
 
 // Example showing how to update the UI using the QueueMain function


### PR DESCRIPTION
Fix the support of "updateui.go" in Windows
- Missing _ "github.com/andlabs/ui/winmanifest" cannot run in Windows