### PR TITLE
expose C.uiUninit() function

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@
 package ui
 
 import (
-	"runtime"
 	"errors"
+	"runtime"
 	"sync"
 	"unsafe"
 )
@@ -52,9 +52,9 @@ func Quit() {
 // These prevent the passing of Go functions into C land.
 // TODO make an actual sparse list instead of this monotonic map thingy
 var (
-	qmmap = make(map[uintptr]func())
+	qmmap     = make(map[uintptr]func())
 	qmcurrent = uintptr(0)
-	qmlock sync.Mutex
+	qmlock    sync.Mutex
 )
 
 // QueueMain queues f to be executed on the GUI thread when
@@ -64,11 +64,11 @@ var (
 // primary purpose is to allow communication between other
 // goroutines and the GUI thread. Calling QueueMain after Quit
 // has been called results in undefined behavior.
-// 
+//
 // If you start a goroutine in f, it also cannot call package ui
 // functions. So for instance, the following will result in
 // undefined behavior:
-// 
+//
 // 	ui.QueueMain(func() {
 // 		go ui.MsgBox(...)
 // 	})

--- a/main.go
+++ b/main.go
@@ -42,6 +42,11 @@ func Main(f func()) error {
 	return nil
 }
 
+// Uninit calls C.uiUninit to uninitialize all allocated objects
+func Uninit() {
+	C.uiUninit()
+}
+
 // Quit queues a return from Main. It does not exit the program.
 // It also does not immediately cause Main to return; Main will
 // return when it next can. Quit must be called from the GUI thread.


### PR DESCRIPTION
I was unable to close the ui properly and reopen it again. So I am wondering if someone else would be facing this problem.
After looking in the libui library, I realize the I had to call the `C.uiUninit()` when I am done. For example:

- https://github.com/andlabs/libui/blob/fea45b2d5b75839be0af9acc842a147c5cba9295/darwin/main.m#L140
- https://github.com/andlabs/libui/blob/fea45b2d5b75839be0af9acc842a147c5cba9295/_wip/examples_opentype/main.c#L199

In order to fix my problem I had to extend the libui library and expose the Uninit function. Afterwards all allocated objects were closed properly and I was able to reopen the ui without the need of restarting my application

Thank you very much